### PR TITLE
feat(hooks): use richer axios client in hooks

### DIFF
--- a/src/database/axios/axios-client.ts
+++ b/src/database/axios/axios-client.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
-axios.defaults.baseURL = `${process.env.REACT_APP_IWA_API_URL}`;
-axios.defaults.headers.common = {
+const richAxios = axios;
+
+richAxios.defaults.baseURL = `${process.env.REACT_APP_IWA_API_URL}`;
+richAxios.defaults.headers.common = {
   Authorization: `Bearer ${localStorage.getItem('token')}`,
 };
-export default axios;
+export default richAxios;

--- a/src/hooks/generic/useFetchMany.ts
+++ b/src/hooks/generic/useFetchMany.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { useEffect, useState } from 'react';
+import richAxios from '../../database/axios/axios-client';
 
 export default function useFetchMany<T>(
   path: string,
@@ -10,8 +10,8 @@ export default function useFetchMany<T>(
 
   useEffect(() => {
     (async function () {
-      axios
-        .get<T[]>(process.env.REACT_APP_IWA_API_URL + path)
+      richAxios
+        .get<T[]>(path)
         .then((response) => setData(response.data))
         .catch((err) => {
           setError(err);

--- a/src/hooks/generic/useFetchOne.ts
+++ b/src/hooks/generic/useFetchOne.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { useEffect, useState } from 'react';
+import richAxios from '../../database/axios/axios-client';
 
 export default function useFetch<T>(
   path: string,
@@ -10,8 +10,8 @@ export default function useFetch<T>(
 
   useEffect(() => {
     (async function () {
-      axios
-        .get<T>(process.env.REACT_APP_IWA_API_URL + path)
+      richAxios
+        .get<T>(path)
         .then((response) => setData(response.data))
         .catch((err) => {
           setError(err);

--- a/src/hooks/generic/usePost.ts
+++ b/src/hooks/generic/usePost.ts
@@ -1,8 +1,10 @@
-import axios from 'axios';
+import richAxios from '../../database/axios/axios-client';
+
+// Not really a hook so it can bypass React's hooks rules
 
 const usePost = <U, V>(
   path: string,
   dataToSend: U,
-) => axios.post<V>(process.env.REACT_APP_IWA_API_URL + path, dataToSend);
+) => richAxios.post<V>(path, dataToSend);
 
 export default usePost;


### PR DESCRIPTION
Replaced the old axios client used in request hooks with a richer one which sets default parameters for all requests.